### PR TITLE
Ensure report.R and plot.R are available inside distributions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prepublish": "tsc",
+    "prepublish": "tsc && cp ./{report.R,plot.R} ./dist/",
     "build": "tsc",
     "compile": "tsc --watch",
     "lint": "tslint -p tsconfig.json",


### PR DESCRIPTION
In Ember Macro Benchmark there lives a report.R file that is no longer
compatible with chrome-tracing 0.10.0.  It makes sense for us to ship
the R files responsible for generating useful reports along with this
library as this library also controls/produces the input for said reports
(results.json).

Once this is in a stable release we can update Ember Macro Benchmark to
point to these R files with an npm script