### PR TITLE
Ensure executables are in the packed build

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "dist/index.d.ts",
     "dist/index.js",
     "dist/index.js.map",
-    "dist/lib"
+    "dist/lib",
+    "bin"
   ],
   "keywords": [
     "chrome",


### PR DESCRIPTION
Using the `bin` directive to specify an executable in your
package.json does not guarantee that once `npm pack` has been run the
files will be available.

This PR ensures the executables are there to put into .bin.